### PR TITLE
Fix typo in extension.ts.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,7 +234,7 @@ export async function activate(context: ExtensionContext) {
 
   if (versions === undefined) {
     denoStatus = Status.warn;
-    statusBarItem.tooltip = "Deno does not installed";
+    statusBarItem.tooltip = "Deno is not installed";
     outputChannel.appendLine("Failed to detect Deno.");
     outputChannel.appendLine("You can use one-line commands to install Deno.");
     if (process.platform === "win32") {


### PR DESCRIPTION
`Deno does not installed` -> `Deno is not installed`

<!--

Thank you for being interested in vscode-deno!

Have you read vscode-deno's Code of Conduct? https://github.com/justjavac/vscode-deno/blob/master/CODE_OF_CONDUCT.md

Before making a PR, please read our contributing guidelines
https://github.com/justjavac/vscode-deno/blob/master/CONTRIBUTING.md

-->
