### PR TITLE
Remove formatter autosave override

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,11 +116,9 @@
     ],
     "configurationDefaults": {
       "[typescript]": {
-        "editor.formatOnSave": false,
         "editor.defaultFormatter": "justjavac.vscode-deno"
       },
       "[markdown]": {
-        "editor.formatOnSave": false,
         "editor.defaultFormatter": "justjavac.vscode-deno"
       }
     }


### PR DESCRIPTION
Currently vscode-deno overrides the format autosave option. This means that while the vscode-deno extension is installed no other formatters for js and ts can run automatically on save, as vscode gives extensions the priority over global user settings. This change removes the autosave disable override. 