### PR TITLE
fix "Deno not found" bug on Linux

### DIFF
--- a/src/deno.ts
+++ b/src/deno.ts
@@ -206,7 +206,7 @@ async function findSpecificDeno(
 ): Promise<IDeno> {
   onLookup(path);
 
-  const ps = await execa(path, ["version"]);
+  const ps = await execa(path, ["--version"]);
 
   if (ps.exitCode) {
     throw new Error("Not found");


### PR DESCRIPTION
`deno version` is not a valid argument. `deno --version` is the correct argument.