### PR TITLE
update prettier link to 3rd party modules

### DIFF
--- a/snippets/deno.json
+++ b/snippets/deno.json
@@ -66,7 +66,7 @@
   "Import 'prettier' modules": {
     "prefix": "import",
     "body": [
-      "import * as prettier from \"https://deno.land/x/std/prettier/prettier.ts\";",
+      "import * as prettier from \"https://deno.land/x/prettier/prettier.ts\";",
       "$0"
     ],
     "description": "import 'prettier' modules"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -206,7 +206,7 @@ export async function activate(context: ExtensionContext) {
           [
             "run",
             "--allow-read",
-            "https://deno.land/std/prettier/main.ts",
+            "https://deno.land/x/prettier/main.ts",
             filename
           ],
           { cwd }


### PR DESCRIPTION
It looks like [prettier has moved to to denolib](https://github.com/denolib/prettier)

These changes fix the extension throwing an error about not being able to pull the the code from the deno standard library when trying to format documents.